### PR TITLE
Fixing up for different screens

### DIFF
--- a/src/Cannons.json
+++ b/src/Cannons.json
@@ -4,8 +4,7 @@
     "pixel_height": 251,
 
     "pivot_x": 227,
-    "pivot_y": 118,
-    "growth_factor": 0.5
+    "pivot_y": 118
   },
   
   "holster_v1": {
@@ -13,7 +12,6 @@
     "pixel_height": 298,
 
     "pivot_x": 65,
-    "pivot_y": 60,
-    "growth_factor": 0.5
+    "pivot_y": 60
   }
 }

--- a/src/Cannons.json
+++ b/src/Cannons.json
@@ -2,8 +2,7 @@
   "v2": {
     "pixel_width": 849,
     "pixel_height": 251,
-    "scalar_top_corner_x": 0.032,
-    "scalar_top_corner_y": 0.70,
+
     "pivot_x": 227,
     "pivot_y": 118,
     "growth_factor": 0.5
@@ -12,8 +11,7 @@
   "holster_v1": {
     "pixel_width": 123,
     "pixel_height": 298,
-    "scalar_top_corner_x": 0.06,
-    "scalar_top_corner_y": 0.73,
+
     "pivot_x": 65,
     "pivot_y": 60,
     "growth_factor": 0.5

--- a/src/Cannons.json
+++ b/src/Cannons.json
@@ -14,6 +14,8 @@
     "pixel_height": 298,
     "scalar_top_corner_x": 0.06,
     "scalar_top_corner_y": 0.73,
+    "pivot_x": 65,
+    "pivot_y": 60,
     "growth_factor": 0.5
   }
 }

--- a/src/components/CSS/Canvas.css
+++ b/src/components/CSS/Canvas.css
@@ -13,9 +13,11 @@ img {
 }
 
 #angleInput {
-    margin-left: 40%;
-    position: relative;
-    bottom: 50vh;
+    margin-left: 1vw;
+    margin-bottom: 1vw;
+    position: fixed;
+    bottom: 0;
+    left: 0;
     background-color: white;
     padding: 15px 10px;
 

--- a/src/components/CSS/Canvas.css
+++ b/src/components/CSS/Canvas.css
@@ -1,6 +1,6 @@
 #canvas {
     background-image: url(../../images/fillerBGImage.jpg);
-    background-size: cover;
+    background-size: contain;
     width: 200%;
     background-repeat: repeat-x;
     

--- a/src/components/CSS/Canvas.css
+++ b/src/components/CSS/Canvas.css
@@ -1,10 +1,11 @@
 #canvas {
     background-image: url(../../images/fillerBGImage.jpg);
-    background-size: contain;
+    background-size: cover;
     width: 200%;
+    background-repeat: repeat-x;
     
     background-color: rgb(255, 225, 225);
-    background-repeat: repeat-x;
+
 }
 
 img { 
@@ -47,12 +48,10 @@ input {
 #fireButton {
     width: 90px;
     height: 60px;
+    position: fixed;
+    left: 50%;
+    margin-left: -45px;
+    bottom: 0;
+
     border: black 2px solid;
-}
-
-
-@media (orientation: portrait) {
-    #canvas {
-        background-size: cover;
-    }
 }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,6 +20,8 @@ export default function Canvas() {
 
   const ctxRef = useRef(null);
 
+  const USER_ANCHOR_POINT = useRef([0.1, 0.90])
+
   const { width, height } = useWindowSize();
 
   const canvasRef = useRef(null);
@@ -63,9 +65,10 @@ export default function Canvas() {
     drawDefaultCannon(
       ctxRef.current, canvasRef.current, 
       cannonRef.current, holsterRef.current, 
-      cannonInfo, holsterInfo
+      cannonInfo, holsterInfo,
+      USER_ANCHOR_POINT.current
     );
-  }, [ctxRef, cannonInfo, holsterInfo])
+  }, [ctxRef, cannonInfo, holsterInfo, USER_ANCHOR_POINT])
 
   useEffect(() => {
     ctxRef.current = canvasRef.current.getContext('2d');
@@ -76,14 +79,15 @@ export default function Canvas() {
     drawRotatedCannon(ctxRef.current, canvasRef.current, 
       -elevationAngle, 
       cannonRef.current, holsterRef.current, 
-      cannonInfo, holsterInfo
+      cannonInfo, holsterInfo,
+      USER_ANCHOR_POINT.current
     );
 
     // drawing a scrappy target
     // say i want to get a target 400 m away
     // 1 metre = 5 pixels is my conversion rate atm
     const [piv_x, piv_y] = findPivotGlobalCoords(
-      canvasRef.current, elevationAngle, cannonInfo
+      canvasRef.current, USER_ANCHOR_POINT.current
     )
 
     console.log(`available space = ${(2 * width - piv_x) * 9/10}`)
@@ -134,7 +138,8 @@ export default function Canvas() {
       e.pageX, e.pageY,
       cannonInfo, 
       elevationAngle,
-      clickedBehindPivot
+      clickedBehindPivot,
+      USER_ANCHOR_POINT.current
     )
 
     click_x.current = e.pageX;
@@ -147,8 +152,10 @@ export default function Canvas() {
         e.pageX, e.pageY, 
         click_x.current, click_y.current, clickedBehindPivot.current,
         cannonInfo, 
-        canvasRef.current.width, canvasRef.current.height, 
-        elevationAngle);
+        canvasRef.current,
+        elevationAngle,
+        USER_ANCHOR_POINT.current
+      );
 
       click_x.current = e.pageX;
       click_y.current = e.pageY;
@@ -173,7 +180,7 @@ export default function Canvas() {
     try {
       if (canvasRef.current) {
         const [initial_x, initial_y] 
-          = findPivotGlobalCoords(canvasRef.current, elevationAngle, cannonInfo)
+          = findPivotGlobalCoords(canvasRef.current, USER_ANCHOR_POINT.current)
 
         const availableSpace = (2 * width - initial_x) * 9/10;
         const conversionRate = availableSpace / 500;

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,7 +20,7 @@ export default function Canvas() {
 
   const ctxRef = useRef(null);
 
-  const USER_ANCHOR_POINT = useRef([0.1, 0.90])
+  const USER_ANCHOR_POINT = useRef([0.15, 0.90])
 
   const { width, height } = useWindowSize();
 

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -20,7 +20,7 @@ export default function Canvas() {
 
   const ctxRef = useRef(null);
 
-  const USER_ANCHOR_POINT = useRef([0.15, 0.90])
+  const USER_ANCHOR_POINT = useRef([0.15, 0.80])
 
   const { width, height } = useWindowSize();
 
@@ -228,7 +228,7 @@ export default function Canvas() {
   return (
     <>
       <canvas ref={canvasRef} 
-        style={{height: 2.5 * height, width: 2 * width}} id="canvas" 
+        style={{height: 1.3 * height, width: 2 * width}} id="canvas" 
         // onClick={(e) => adjustAngle(e)}
         onMouseDown={(e) => mouseDown(e)}
         onMouseUp={() => mouseUp()}

--- a/src/components/resizingHook.js
+++ b/src/components/resizingHook.js
@@ -1,0 +1,29 @@
+// from https://www.c-sharpcorner.com/article/how-to-re-render-the-view-when-the-browser-is-resized-in-reactjs/#:~:text=Upon%20resizing%2C%20update%20state%20variables,use%20the%20window%20resize%20event.
+import { useState, useEffect } from 'react';
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Clean up the event listener on component unmount
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return windowSize;
+};
+
+export default useWindowSize;

--- a/src/processingFunctions/calculateAngularDisplacement.js
+++ b/src/processingFunctions/calculateAngularDisplacement.js
@@ -1,17 +1,19 @@
+import { findPivotGlobalCoords } from "./findPivotGlobalCoords";
+
 export function calculateAngularDisplacement(
   mouse_x, mouse_y, init_mouse_x, init_mouse_y, clickedBehindPivot,
   cannonInfo, 
-  canvas_width, canvas_height,
-  angle) 
-{
+  canvas,
+  angle,
+  USER_ANCHOR_POINT
+) {
   
   // mouse_x *= window.devicePixelRatio;
   // mouse_y *= window.devicePixelRatio;
   // init_mouse_x *= window.devicePixelRatio;
   // init_mouse_y *= window.devicePixelRatio;
   
-  const global_piv_x = cannonInfo.scalar_top_corner_x * canvas_width + cannonInfo.pivot_x * cannonInfo.growth_factor;
-  const global_piv_y = cannonInfo.scalar_top_corner_y * canvas_height + cannonInfo.pivot_y * cannonInfo.growth_factor;
+  const [global_piv_x, global_piv_y] = findPivotGlobalCoords(canvas, USER_ANCHOR_POINT);
 
   const a = distanceFormula(global_piv_x, global_piv_y, mouse_x, mouse_y);
   const b = distanceFormula(global_piv_x, global_piv_y, init_mouse_x, init_mouse_y);

--- a/src/processingFunctions/calculateAngularDisplacement.js
+++ b/src/processingFunctions/calculateAngularDisplacement.js
@@ -5,10 +5,10 @@ export function calculateAngularDisplacement(
   angle) 
 {
   
-  mouse_x *= window.devicePixelRatio;
-  mouse_y *= window.devicePixelRatio;
-  init_mouse_x *= window.devicePixelRatio;
-  init_mouse_y *= window.devicePixelRatio;
+  // mouse_x *= window.devicePixelRatio;
+  // mouse_y *= window.devicePixelRatio;
+  // init_mouse_x *= window.devicePixelRatio;
+  // init_mouse_y *= window.devicePixelRatio;
   
   const global_piv_x = cannonInfo.scalar_top_corner_x * canvas_width + cannonInfo.pivot_x * cannonInfo.growth_factor;
   const global_piv_y = cannonInfo.scalar_top_corner_y * canvas_height + cannonInfo.pivot_y * cannonInfo.growth_factor;

--- a/src/processingFunctions/calculateGrowthFactor.js
+++ b/src/processingFunctions/calculateGrowthFactor.js
@@ -1,0 +1,14 @@
+export function calculateGrowthFactorCannon(canvas, cannonInfo) {
+  // LOGIC: say we want the cannon to be ~1/10 of the canvas width
+  // Then get the total width of the canvas
+  // get the width of the cannon
+
+  // cannonWidth * growthFactor = 1/10 * canvasWidth
+  // growthFactor = ( 1/10 * canvasWidth ) / cannonWidth
+
+  // requires cannon_width != 0
+
+  const FRACTION_OF_CANVAS = 1/8;
+
+  return (FRACTION_OF_CANVAS * canvas.width) / cannonInfo.pixel_width
+}

--- a/src/processingFunctions/drawingFunctions.js
+++ b/src/processingFunctions/drawingFunctions.js
@@ -18,8 +18,6 @@ export function getHolsterInfo(name) {
   }
 }
 
-const USER_ANCHOR_POINT = [0.05, 0.90]
-
 /**
  * @param {CanvasRenderingContext2D} ctx - the context for the canvas
  * @param {ImageElement} image - the image you wish to draw
@@ -49,28 +47,23 @@ function drawImageWithRotation(
 
 }
 
-function drawHolster(ctx, canvas, holsterImage, holsterInfo) {
+function drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT) {
   const TOP_LEFT_CORNER = [
-    canvas.width * holsterInfo.scalar_top_corner_x,
-    canvas.height * holsterInfo.scalar_top_corner_y
+    canvas.width * USER_ANCHOR_POINT[0] - holsterInfo.pivot_x * holsterInfo.growth_factor,
+    canvas.height * USER_ANCHOR_POINT[1] - holsterInfo.pivot_y * holsterInfo.growth_factor
   ]
-
-  const growth_factor = holsterInfo.growth_factor;
-
-  ctx.drawImage(
-    holsterImage, 
-    TOP_LEFT_CORNER[0], 
-    TOP_LEFT_CORNER[1], 
-    holsterInfo.pixel_width * growth_factor, 
-    holsterInfo.pixel_height * growth_factor
-  );
+  
+  drawImageWithRotation(ctx, holsterImage, TOP_LEFT_CORNER[0], TOP_LEFT_CORNER[1],
+    holsterInfo.pivot_x, holsterInfo.pivot_y, holsterInfo.pixel_width, 
+    holsterInfo.pixel_height, 0, holsterInfo.growth_factor
+  )
 }
 
-function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo) {
+function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT) {
 
   const TOP_LEFT_CORNER = [
-    canvas.width * cannonInfo.scalar_top_corner_x,
-    canvas.height * cannonInfo.scalar_top_corner_y
+    canvas.width * USER_ANCHOR_POINT[0] - cannonInfo.pivot_x * cannonInfo.growth_factor,
+    canvas.height * USER_ANCHOR_POINT[1] - cannonInfo.pivot_y * cannonInfo.growth_factor
   ]
 
   drawImageWithRotation(ctx, cannonImage, TOP_LEFT_CORNER[0], TOP_LEFT_CORNER[1],
@@ -81,17 +74,17 @@ function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo) {
   return TOP_LEFT_CORNER;
 }
 
-export function drawRotatedCannon(ctx, canvas, angle, cannonImage, holsterImage, cannonInfo, holsterInfo) {
-  drawHolster(ctx, canvas, holsterImage, holsterInfo)
-  drawCannon(ctx, canvas, cannonImage, angle, cannonInfo);
+export function drawRotatedCannon(ctx, canvas, angle, cannonImage, holsterImage, cannonInfo, holsterInfo, USER_ANCHOR_POINT) {
+  drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT)
+  drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT);
 }
 
-export function drawDefaultCannon(ctx, canvas, cannonImage, holsterImage, cannonInfo, holsterInfo) {
+export function drawDefaultCannon(ctx, canvas, cannonImage, holsterImage, cannonInfo, holsterInfo, USER_ANCHOR_POINT) {
   holsterImage.onload = () => {
-    drawHolster(ctx, canvas, holsterImage, holsterInfo)
+    drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT)
   }
 
   cannonImage.onload = () => {
-    drawCannon(ctx, canvas, cannonImage, 0, cannonInfo)
+    drawCannon(ctx, canvas, cannonImage, 0, cannonInfo, USER_ANCHOR_POINT)
   }
 }

--- a/src/processingFunctions/drawingFunctions.js
+++ b/src/processingFunctions/drawingFunctions.js
@@ -1,4 +1,5 @@
 import Cannons from "../Cannons.json"
+import { calculateGrowthFactorCannon } from "./calculateGrowthFactor";
 
 export function getCannonInfo(name) {
   try {
@@ -28,63 +29,65 @@ export function getHolsterInfo(name) {
  * @param {number} width - the pixel width of the ORIGINAL IMAGE
  * @param {number} height - the pixel height of the ORIGINAL IMAGE
  * @param {number} angle - the desired angle of rotation (clockwise is the positive direction)
- * @param {number} growth_factor - the scaling factor to be applied to width and height
+ * @param {number} growthFactor - the scaling factor to be applied to width and height
  *  (value between 0 and 1 will shrink the image, value greater than 1 will enlarge
  *  the image)
  */
 function drawImageWithRotation(
-  ctx, image, pos_x, pos_y, pivot_x, pivot_y, width, height, angle, growth_factor
+  ctx, image, pos_x, pos_y, pivot_x, pivot_y, width, height, angle, growthFactor
 ) {
 
-    ctx.translate(pos_x + pivot_x * growth_factor, pos_y + pivot_y * growth_factor);
+    ctx.translate(pos_x + pivot_x * growthFactor, pos_y + pivot_y * growthFactor);
     
     ctx.rotate(angle * Math.PI / 180);
 
-    ctx.drawImage(image, -pivot_x * growth_factor, -pivot_y * growth_factor, width * growth_factor, height * growth_factor);
+    ctx.drawImage(image, -pivot_x * growthFactor, -pivot_y * growthFactor, width * growthFactor, height * growthFactor);
     ctx.rotate(-angle * Math.PI / 180);
     
-    ctx.translate(-pos_x - pivot_x * growth_factor, -pos_y - pivot_y * growth_factor)
+    ctx.translate(-pos_x - pivot_x * growthFactor, -pos_y - pivot_y * growthFactor)
 
 }
 
-function drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT) {
+function drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT, growthFactor) {
   const TOP_LEFT_CORNER = [
-    canvas.width * USER_ANCHOR_POINT[0] - holsterInfo.pivot_x * holsterInfo.growth_factor,
-    canvas.height * USER_ANCHOR_POINT[1] - holsterInfo.pivot_y * holsterInfo.growth_factor
+    canvas.width * USER_ANCHOR_POINT[0] - holsterInfo.pivot_x * growthFactor,
+    canvas.height * USER_ANCHOR_POINT[1] - holsterInfo.pivot_y * growthFactor
   ]
   
   drawImageWithRotation(ctx, holsterImage, TOP_LEFT_CORNER[0], TOP_LEFT_CORNER[1],
     holsterInfo.pivot_x, holsterInfo.pivot_y, holsterInfo.pixel_width, 
-    holsterInfo.pixel_height, 0, holsterInfo.growth_factor
+    holsterInfo.pixel_height, 0, growthFactor
   )
 }
 
-function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT) {
+function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT, growthFactor) {
 
   const TOP_LEFT_CORNER = [
-    canvas.width * USER_ANCHOR_POINT[0] - cannonInfo.pivot_x * cannonInfo.growth_factor,
-    canvas.height * USER_ANCHOR_POINT[1] - cannonInfo.pivot_y * cannonInfo.growth_factor
+    canvas.width * USER_ANCHOR_POINT[0] - cannonInfo.pivot_x * growthFactor,
+    canvas.height * USER_ANCHOR_POINT[1] - cannonInfo.pivot_y * growthFactor
   ]
 
   drawImageWithRotation(ctx, cannonImage, TOP_LEFT_CORNER[0], TOP_LEFT_CORNER[1],
     cannonInfo.pivot_x, cannonInfo.pivot_y, cannonInfo.pixel_width, 
-    cannonInfo.pixel_height, angle, cannonInfo.growth_factor
+    cannonInfo.pixel_height, angle, growthFactor
   )
 
   return TOP_LEFT_CORNER;
 }
 
 export function drawRotatedCannon(ctx, canvas, angle, cannonImage, holsterImage, cannonInfo, holsterInfo, USER_ANCHOR_POINT) {
-  drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT)
-  drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT);
+  const growthFactor = calculateGrowthFactorCannon(canvas, cannonInfo)
+  drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT, growthFactor)
+  drawCannon(ctx, canvas, cannonImage, angle, cannonInfo, USER_ANCHOR_POINT, growthFactor);
 }
 
 export function drawDefaultCannon(ctx, canvas, cannonImage, holsterImage, cannonInfo, holsterInfo, USER_ANCHOR_POINT) {
+  const growthFactor = calculateGrowthFactorCannon(canvas, cannonInfo);
   holsterImage.onload = () => {
-    drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT)
+    drawHolster(ctx, canvas, holsterImage, holsterInfo, USER_ANCHOR_POINT, growthFactor)
   }
 
   cannonImage.onload = () => {
-    drawCannon(ctx, canvas, cannonImage, 0, cannonInfo, USER_ANCHOR_POINT)
+    drawCannon(ctx, canvas, cannonImage, 0, cannonInfo, USER_ANCHOR_POINT, growthFactor)
   }
 }

--- a/src/processingFunctions/drawingFunctions.js
+++ b/src/processingFunctions/drawingFunctions.js
@@ -1,6 +1,5 @@
 import Cannons from "../Cannons.json"
 
-
 export function getCannonInfo(name) {
   try {
     return Cannons[name];
@@ -18,6 +17,8 @@ export function getHolsterInfo(name) {
     console.error(e.message);
   }
 }
+
+const USER_ANCHOR_POINT = [0.05, 0.90]
 
 /**
  * @param {CanvasRenderingContext2D} ctx - the context for the canvas
@@ -56,7 +57,13 @@ function drawHolster(ctx, canvas, holsterImage, holsterInfo) {
 
   const growth_factor = holsterInfo.growth_factor;
 
-  ctx.drawImage(holsterImage, TOP_LEFT_CORNER[0], TOP_LEFT_CORNER[1], holsterInfo.pixel_width * growth_factor, holsterInfo.pixel_height * growth_factor);
+  ctx.drawImage(
+    holsterImage, 
+    TOP_LEFT_CORNER[0], 
+    TOP_LEFT_CORNER[1], 
+    holsterInfo.pixel_width * growth_factor, 
+    holsterInfo.pixel_height * growth_factor
+  );
 }
 
 function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo) {
@@ -75,8 +82,6 @@ function drawCannon(ctx, canvas, cannonImage, angle, cannonInfo) {
 }
 
 export function drawRotatedCannon(ctx, canvas, angle, cannonImage, holsterImage, cannonInfo, holsterInfo) {
-
-  // drawHolster(ctx, canvas, holsterImage);
   drawHolster(ctx, canvas, holsterImage, holsterInfo)
   drawCannon(ctx, canvas, cannonImage, angle, cannonInfo);
 }

--- a/src/processingFunctions/findPivotGlobalCoords.js
+++ b/src/processingFunctions/findPivotGlobalCoords.js
@@ -1,16 +1,7 @@
-export function findPivotGlobalCoords(canvas, angle, cannonInfo) {
-  const pivX = canvas.width * cannonInfo.scalar_top_corner_x + 
-    cannonInfo.pivot_x * cannonInfo.growth_factor
+export function findPivotGlobalCoords(canvas, USER_ANCHOR_POINT) {
+  const pivX = canvas.width * USER_ANCHOR_POINT[0]
 
-  const pivY = canvas.height * cannonInfo.scalar_top_corner_y + 
-    cannonInfo.pivot_y * cannonInfo.growth_factor
-  
-  // const magnitude = cannonInfo.growth_factor * (cannonInfo.pixel_width - cannonInfo.pivot_x);
-
-  // const angle_rad = angle * (Math.PI / 180)
-  // const vector = [magnitude * Math.cos(angle_rad), -magnitude * Math.sin(angle_rad)];
-
-  // return [pivX + vector[0], pivY + vector[1]]
+  const pivY = canvas.height * USER_ANCHOR_POINT[1]
 
   return [pivX, pivY]
 }

--- a/src/processingFunctions/readingPixels.js
+++ b/src/processingFunctions/readingPixels.js
@@ -1,3 +1,4 @@
+import { calculateGrowthFactorCannon } from "./calculateGrowthFactor";
 import { findPivotGlobalCoords } from "./findPivotGlobalCoords";
 
 export function clickedOnCannon(
@@ -17,10 +18,10 @@ export function clickedOnCannon(
 
   if (angle === 90) {
     mu = (mouse_x - TOP_LEFT_CORNER[0]) / 
-      ((cannonInfo.pixel_height) * cannonInfo.growth_factor)
+      ((cannonInfo.pixel_height) * calculateGrowthFactorCannon(canvas, cannonInfo))
 
     lambda = (TOP_LEFT_CORNER[1] - mouse_y) / 
-      ((cannonInfo.pixel_width) * cannonInfo.growth_factor);
+      ((cannonInfo.pixel_width) * calculateGrowthFactorCannon(canvas, cannonInfo));
   }
 
   if (lambda < 0 || lambda > 1 || mu < 0 || mu > 1) {
@@ -50,7 +51,7 @@ export function clickedOnCannon(
 
 function findCannonPointAndPlane(canvas, cannonInfo, angle, USER_ANCHOR_POINT) {
   
-  const growthFactor = cannonInfo.growth_factor;
+  const growthFactor = calculateGrowthFactorCannon(canvas, cannonInfo)
   
   const [PIVOT_X_GLOBAL, PIVOT_Y_GLOBAL] = findPivotGlobalCoords(canvas, USER_ANCHOR_POINT)
   

--- a/src/processingFunctions/readingPixels.js
+++ b/src/processingFunctions/readingPixels.js
@@ -1,6 +1,11 @@
-export function clickedOnCannon(ctx, canvas, mouse_x, mouse_y, cannonInfo, angle, clickedBehindPivot) {
+import { findPivotGlobalCoords } from "./findPivotGlobalCoords";
 
-  const [TOP_LEFT_CORNER, v1, v2] = findCannonPointAndPlane(ctx, canvas, cannonInfo, angle);
+export function clickedOnCannon(
+  ctx, canvas, mouse_x, mouse_y, cannonInfo, angle, clickedBehindPivot,
+  USER_ANCHOR_POINT
+) {
+
+  const [TOP_LEFT_CORNER, v1, v2] = findCannonPointAndPlane(canvas, cannonInfo, angle, USER_ANCHOR_POINT);
   // mouse_x *= window.devicePixelRatio;
   // mouse_y *= window.devicePixelRatio;
 
@@ -43,15 +48,11 @@ export function clickedOnCannon(ctx, canvas, mouse_x, mouse_y, cannonInfo, angle
  return !transparency;
 }
 
-function findCannonPointAndPlane(ctx, canvas, cannonInfo, angle) {
-  const W = canvas.width;
-  const H = canvas.height;
+function findCannonPointAndPlane(canvas, cannonInfo, angle, USER_ANCHOR_POINT) {
   
   const growthFactor = cannonInfo.growth_factor;
   
-  const PIVOT_X_GLOBAL = W * cannonInfo.scalar_top_corner_x + cannonInfo.pivot_x * growthFactor;
-  const PIVOT_Y_GLOBAL = H * cannonInfo.scalar_top_corner_y + cannonInfo.pivot_y * growthFactor;
-
+  const [PIVOT_X_GLOBAL, PIVOT_Y_GLOBAL] = findPivotGlobalCoords(canvas, USER_ANCHOR_POINT)
   
   const angle_rad = angle * Math.PI / 180
 

--- a/src/processingFunctions/readingPixels.js
+++ b/src/processingFunctions/readingPixels.js
@@ -1,8 +1,8 @@
 export function clickedOnCannon(ctx, canvas, mouse_x, mouse_y, cannonInfo, angle, clickedBehindPivot) {
 
   const [TOP_LEFT_CORNER, v1, v2] = findCannonPointAndPlane(ctx, canvas, cannonInfo, angle);
-  mouse_x *= window.devicePixelRatio;
-  mouse_y *= window.devicePixelRatio;
+  // mouse_x *= window.devicePixelRatio;
+  // mouse_y *= window.devicePixelRatio;
 
 
   var [lambda, mu] = calculateLambdaAndMu(TOP_LEFT_CORNER, v1[0], v1[1], v2[0], v2[1], mouse_x, mouse_y);


### PR DESCRIPTION
Completed the following tasks as per Issue 22 (Friendly for different sizes of screen)
- Positioned holster and cannon at the same global point on the canvas; did this by choosing a point on the canvas and having the pivot points of the cannon and the holster anchored to that canvas point
- Moved the angle text box input behind the cannon so that it does not obscure the cannon nor the cannon ball trajectory
- Dynamically create a growth factor based on the screen width rather than making the growth factor a constant

- Background needs to be further considered so that it makes sense with the cannon for different screens