### PR TITLE
Redoing on load stuff

### DIFF
--- a/src/OOP/DrawingImages.js
+++ b/src/OOP/DrawingImages.js
@@ -307,7 +307,6 @@ export class DrawingImages {
     USER_ANCHOR_POINT,
     MAX_SPEED,
     launchVelocity,
-    
     elevationAngle,
     target_range,
     target_altitude,

--- a/src/OOP/DrawingImages.js
+++ b/src/OOP/DrawingImages.js
@@ -8,42 +8,22 @@ export class DrawingImages {
   }
 
   ////// Cannon Drawing
-  drawDefaultCannon(cannonImage, holsterImage, USER_ANCHOR_POINT) {
+  drawHolsterOnLoad(holsterImage, USER_ANCHOR_POINT) {
     holsterImage.onload = () => {
-      this.#drawHolster(
-        holsterImage, 
-        USER_ANCHOR_POINT, 
-      )
-
-      cannonImage.onload = () => {
-        this.#drawCannon(
-          cannonImage, 
-          0, 
-          USER_ANCHOR_POINT,
-          0
-        )
-      }
+      this.drawHolster(holsterImage, USER_ANCHOR_POINT);
     }
+    console.log("Completed holster on load")
   }
 
-  drawRotatedCannon(angle, cannonImage, holsterImage, USER_ANCHOR_POINT) {
-    this.#drawHolster(
-      holsterImage,
-      USER_ANCHOR_POINT,
-      
-    );
+  drawCannonOnLoad(cannonImage, USER_ANCHOR_POINT) {
+    cannonImage.onload = () => {
+      this.drawCannon(cannonImage, 0, USER_ANCHOR_POINT);
+    }
 
-    this.#drawCannon(
-      cannonImage,
-      angle,
-      USER_ANCHOR_POINT,
-      
-    )
-
+    console.log("Completed cannon on load")
   }
 
-  #drawHolster(holsterImage, USER_ANCHOR_POINT) {
-    const canvas = this.#canvasPositionAndSizes.getCanvas();
+  drawHolster(holsterImage, USER_ANCHOR_POINT) {
     const holsterInfo = this.#canvasPositionAndSizes.getHolsterInfo();
 
     const growthFactor = this.#canvasPositionAndSizes.getGrowthFactorCannon();
@@ -67,8 +47,7 @@ export class DrawingImages {
     )
   }
 
-  #drawCannon(cannonImage, angle, USER_ANCHOR_POINT) {
-    const canvas = this.#canvasPositionAndSizes.getCanvas();
+  drawCannon(cannonImage, angle, USER_ANCHOR_POINT) {
     const cannonInfo = this.#canvasPositionAndSizes.getCannonInfo();
 
     const growthFactor = this.#canvasPositionAndSizes.getGrowthFactorCannon();
@@ -94,52 +73,13 @@ export class DrawingImages {
 
   //// Velocity Methods
 
-  drawDefaultVelocitySlider(velocityBar, velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
+  drawVelocityBar(velocityBar, USER_ANCHOR_POINT) {
     const [pos_x, pos_y] = this.#canvasPositionAndSizes.getVelocityBarPosition(USER_ANCHOR_POINT);
     const growthFactor = this.#canvasPositionAndSizes.getGrowthFactorVelocity();
-    velocityBar.onload = () => {
-
-      drawImageWithRotation(
-        this.#canvasPositionAndSizes.getCtx(), 
-        velocityBar, 
-        pos_x, 
-        pos_y, 
-        0, 
-        0, 
-        817, 
-        25, 
-        0, 
-        growthFactor
-      )
-      const pixelPerVelocity =  (817 * growthFactor) / MAX_SPEED;
-      const sliderPosX = pos_x + pixelPerVelocity * launchVelocity - 50/2 * growthFactor;
-      const sliderPosY = pos_y - 51/4 * growthFactor;
-    
-      velocitySlider.onload = () => {
-        drawImageWithRotation(
-          this.#canvasPositionAndSizes.getCtx(),  
-          velocitySlider, 
-          sliderPosX, sliderPosY, 
-          0, 
-          0, 
-          50, 
-          51, 
-          0, 
-          growthFactor
-        )
-      }
-    }
-  }
-
-  drawVelocitySlider(velocityBar, velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
-
-    const [pos_x, pos_y] = this.#canvasPositionAndSizes.getVelocityBarPosition(USER_ANCHOR_POINT);
-    const growthFactor = this.#canvasPositionAndSizes.getGrowthFactorVelocity();
-
     drawImageWithRotation(
       this.#canvasPositionAndSizes.getCtx(), 
       velocityBar, 
-      pos_x , 
+      pos_x, 
       pos_y, 
       0, 
       0, 
@@ -148,17 +88,28 @@ export class DrawingImages {
       0, 
       growthFactor
     )
+  }
 
-    const sliderPosY = pos_y - 51/4 * growthFactor;
+  drawVelocityBarOnLoad(velocityBar, USER_ANCHOR_POINT) {
+    velocityBar.onload = () => {
+      this.drawVelocityBar(velocityBar, USER_ANCHOR_POINT)
+    }
+
+    console.log("Completed vel bar on load")
+  }
+
+  drawVelocitySlider(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
+    const [pos_x, pos_y] = this.#canvasPositionAndSizes.getVelocityBarPosition(USER_ANCHOR_POINT);
+    const growthFactor = this.#canvasPositionAndSizes.getGrowthFactorVelocity();
 
     const pixelPerVelocity =  (817 * growthFactor) / MAX_SPEED;
     const sliderPosX = pos_x + pixelPerVelocity * launchVelocity - 50/2 * growthFactor;
+    const sliderPosY = pos_y - 51/4 * growthFactor;
 
     drawImageWithRotation(
       this.#canvasPositionAndSizes.getCtx(),  
       velocitySlider, 
-      sliderPosX , 
-      sliderPosY, 
+      sliderPosX, sliderPosY, 
       0, 
       0, 
       50, 
@@ -168,50 +119,21 @@ export class DrawingImages {
     )
   }
 
-
-
-  drawDefaultHeightScale(heightScale, heightArrow, USER_ANCHOR_POINT) {
-
-    const [pos_x, pos_y] = this.#canvasPositionAndSizes.getHeightScalePosition(USER_ANCHOR_POINT);
-    const growthFactor =  this.#canvasPositionAndSizes.getGrowthFactorHeight();
-    heightScale.onload = () => {
-      drawImageWithRotation(
-        this.#canvasPositionAndSizes.getCtx(),
-        heightScale, 
-        pos_x, 
-        pos_y, 
-        0, 
-        0, 
-        158, 
-        917, 
-        0, 
-        growthFactor
-      );
-      // TODO: add this code to the top left corner file
-      const [arrowPosX, arrowPosY] = this.#canvasPositionAndSizes.getHeightArrowPosition(USER_ANCHOR_POINT);
-      drawImageWithRotation(
-        this.#canvasPositionAndSizes.getCtx(), 
-        heightArrow, 
-        arrowPosX, 
-        arrowPosY, 
-        0, 
-        0, 
-        103, 
-        63, 
-        0, 
-        growthFactor
-      );
+  drawVelocitySliderOnLoad(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
+    velocitySlider.onload = () => {
+      this.drawVelocitySlider(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT)
     }
-    
+
+    console.log("Completed vel slider on load")
   }
-  //// Draw Height Scale
-  drawHeightScale(heightScale, heightArrow, USER_ANCHOR_POINT) {
+
+  drawHeightScale(heightScale, USER_ANCHOR_POINT) {
     const [pos_x, pos_y] = this.#canvasPositionAndSizes.getHeightScalePosition(USER_ANCHOR_POINT);
     const growthFactor =  this.#canvasPositionAndSizes.getGrowthFactorHeight();
     drawImageWithRotation(
-      this.#canvasPositionAndSizes.getCtx(), 
+      this.#canvasPositionAndSizes.getCtx(),
       heightScale, 
-      pos_x , 
+      pos_x, 
       pos_y, 
       0, 
       0, 
@@ -220,12 +142,25 @@ export class DrawingImages {
       0, 
       growthFactor
     );
+  }
 
+  drawHeightScaleOnLoad(heightScale, USER_ANCHOR_POINT) {
+    heightScale.onload = () => {
+      this.drawHeightScale(heightScale, USER_ANCHOR_POINT);
+    }
+
+    console.log("Completed height scale on load")
+  }
+
+  drawHeightArrow(heightArrow, USER_ANCHOR_POINT) {
+    const growthFactor =  this.#canvasPositionAndSizes.getGrowthFactorHeight();
+    
     const [arrowPosX, arrowPosY] = this.#canvasPositionAndSizes.getHeightArrowPosition(USER_ANCHOR_POINT);
+    
     drawImageWithRotation(
       this.#canvasPositionAndSizes.getCtx(), 
       heightArrow, 
-      arrowPosX , 
+      arrowPosX, 
       arrowPosY, 
       0, 
       0, 
@@ -234,6 +169,14 @@ export class DrawingImages {
       0, 
       growthFactor
     );
+  }
+
+  drawHeightArrowOnLoad(heightArrow, USER_ANCHOR_POINT) {
+    heightArrow.onload = () => {
+      this.drawHeightArrow(heightArrow, USER_ANCHOR_POINT);
+    }
+
+    console.log("Completed height arrow on load")
   }
 
   drawHeightPlatform(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR) {
@@ -281,15 +224,18 @@ export class DrawingImages {
     foreground.onload = () => {
       this.drawForeground(GROUND_LEVEL_SCALAR, foreground);
     }
+    console.log("Completed foreground on load")
   }
 
-  drawTargetOnLoad(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR=0.8, target, range, altitude) {
+  drawTargetOnLoad(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude) {
     target.onload = () => {
-      this.drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR=0.8, target, range, altitude)
+      this.drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude)
     }
+
+    console.log("Completed target on load")
   }
 
-  drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR=0.8, target, range, altitude) {
+  drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude) {
     const conversionRate = this.#canvasPositionAndSizes.calculateConversionRate(USER_ANCHOR_POINT);
     const growthFactor = 0.5;
 
@@ -312,5 +258,95 @@ export class DrawingImages {
       0,
       growthFactor
     )
+  }
+
+  drawEnvironmentOnLoad(
+    GROUND_LEVEL_SCALAR, 
+    USER_ANCHOR_POINT,
+    MAX_SPEED,
+    launchVelocity,
+    target_range,
+    target_altitude,
+    foregroundRef, 
+    holsterRef, 
+    cannonRef, 
+    velocityBarRef, 
+    velocitySliderRef, 
+    heightScaleRef, 
+    heightArrowRef,
+    targetRef
+  ) {
+
+
+    this.drawForegroundOnLoad(GROUND_LEVEL_SCALAR, foregroundRef.current);
+    
+    this.drawHolsterOnLoad(holsterRef.current, USER_ANCHOR_POINT);
+    this.drawCannonOnLoad(cannonRef.current, USER_ANCHOR_POINT);
+
+
+    this.drawVelocityBarOnLoad(velocityBarRef.current, USER_ANCHOR_POINT);
+    this.drawVelocitySliderOnLoad(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
+
+    this.drawHeightScaleOnLoad(heightScaleRef.current, USER_ANCHOR_POINT);
+    this.drawHeightArrowOnLoad(heightArrowRef.current, USER_ANCHOR_POINT);
+
+    this.drawTargetOnLoad(
+      USER_ANCHOR_POINT, 
+      GROUND_LEVEL_SCALAR, 
+      targetRef.current, 
+      target_range, 
+      target_altitude
+    )
+
+    console.log("completed environment on load")
+
+  }
+
+  drawEnvironment(
+    GROUND_LEVEL_SCALAR, 
+    USER_ANCHOR_POINT,
+    MAX_SPEED,
+    launchVelocity,
+    
+    elevationAngle,
+    target_range,
+    target_altitude,
+    foregroundRef, 
+    holsterRef, 
+    cannonRef, 
+    velocityBarRef, 
+    velocitySliderRef, 
+    heightScaleRef, 
+    heightArrowRef,
+    targetRef
+  ) {
+    const canvas = this.#canvasPositionAndSizes.getCanvas();
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+
+    this.drawForeground(GROUND_LEVEL_SCALAR, foregroundRef.current);
+
+    this.drawHolster(holsterRef.current, USER_ANCHOR_POINT);
+    this.drawCannon(cannonRef.current, -elevationAngle, USER_ANCHOR_POINT);
+
+    this.drawHeightPlatform(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR);
+    
+    this.drawVelocityBar(velocityBarRef.current, USER_ANCHOR_POINT);
+    this.drawVelocitySlider(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
+    
+    this.drawHeightScale(heightScaleRef.current, USER_ANCHOR_POINT);
+    this.drawHeightArrow(heightArrowRef.current, USER_ANCHOR_POINT);
+
+    this.drawTarget(
+      USER_ANCHOR_POINT, 
+      GROUND_LEVEL_SCALAR, 
+      targetRef.current, 
+      target_range, 
+      target_altitude
+    )
+
+    // console.log("Completed environment (not on load)")
+
   }
 }

--- a/src/OOP/DrawingImages.js
+++ b/src/OOP/DrawingImages.js
@@ -12,15 +12,12 @@ export class DrawingImages {
     holsterImage.onload = () => {
       this.drawHolster(holsterImage, USER_ANCHOR_POINT);
     }
-    console.log("Completed holster on load")
   }
 
   drawCannonOnLoad(cannonImage, USER_ANCHOR_POINT) {
     cannonImage.onload = () => {
       this.drawCannon(cannonImage, 0, USER_ANCHOR_POINT);
     }
-
-    console.log("Completed cannon on load")
   }
 
   drawHolster(holsterImage, USER_ANCHOR_POINT) {
@@ -94,8 +91,6 @@ export class DrawingImages {
     velocityBar.onload = () => {
       this.drawVelocityBar(velocityBar, USER_ANCHOR_POINT)
     }
-
-    console.log("Completed vel bar on load")
   }
 
   drawVelocitySlider(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
@@ -117,14 +112,14 @@ export class DrawingImages {
       0, 
       growthFactor
     )
+
+    
   }
 
   drawVelocitySliderOnLoad(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT) {
     velocitySlider.onload = () => {
       this.drawVelocitySlider(velocitySlider, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT)
     }
-
-    console.log("Completed vel slider on load")
   }
 
   drawHeightScale(heightScale, USER_ANCHOR_POINT) {
@@ -148,8 +143,6 @@ export class DrawingImages {
     heightScale.onload = () => {
       this.drawHeightScale(heightScale, USER_ANCHOR_POINT);
     }
-
-    console.log("Completed height scale on load")
   }
 
   drawHeightArrow(heightArrow, USER_ANCHOR_POINT) {
@@ -175,8 +168,6 @@ export class DrawingImages {
     heightArrow.onload = () => {
       this.drawHeightArrow(heightArrow, USER_ANCHOR_POINT);
     }
-
-    console.log("Completed height arrow on load")
   }
 
   drawHeightPlatform(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR) {
@@ -217,22 +208,19 @@ export class DrawingImages {
       302,
       0,
       this.#canvasPositionAndSizes.getGrowthFactorForeground()
-    )
+    ) 
   }
 
   drawForegroundOnLoad(GROUND_LEVEL_SCALAR, foreground) {
     foreground.onload = () => {
       this.drawForeground(GROUND_LEVEL_SCALAR, foreground);
     }
-    console.log("Completed foreground on load")
   }
 
   drawTargetOnLoad(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude) {
     target.onload = () => {
       this.drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude)
     }
-
-    console.log("Completed target on load")
   }
 
   drawTarget(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR, target, range, altitude) {
@@ -274,9 +262,8 @@ export class DrawingImages {
     velocitySliderRef, 
     heightScaleRef, 
     heightArrowRef,
-    targetRef
+    targetRef,
   ) {
-
 
     this.drawForegroundOnLoad(GROUND_LEVEL_SCALAR, foregroundRef.current);
     
@@ -297,9 +284,6 @@ export class DrawingImages {
       target_range, 
       target_altitude
     )
-
-    console.log("completed environment on load")
-
   }
 
   drawEnvironment(
@@ -319,10 +303,11 @@ export class DrawingImages {
     heightArrowRef,
     targetRef
   ) {
+    
     const canvas = this.#canvasPositionAndSizes.getCanvas();
     const ctx = canvas.getContext('2d');
+    
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-
 
     this.drawForeground(GROUND_LEVEL_SCALAR, foregroundRef.current);
 
@@ -344,8 +329,5 @@ export class DrawingImages {
       target_range, 
       target_altitude
     )
-
-    // console.log("Completed environment (not on load)")
-
   }
 }

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -40,7 +40,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
 
   // Positioning Constants
   const GROUND_LEVEL_SCALAR = 0.8;
-  const [CANNON_HORIZONTAL_SCALAR, setCannonHorizontalScalar] = useState(isLandscape() ? 0.6 * window.devicePixelRatio: 0.3 * window.devicePixelRatio);
+  const [CANNON_HORIZONTAL_SCALAR, setCannonHorizontalScalar] = useState(isLandscape() ? 0.5: 0.5);
 
   const [USER_ANCHOR_POINT, setUserAnchorPoint] = useState([CANNON_HORIZONTAL_SCALAR, GROUND_LEVEL_SCALAR])
 
@@ -99,9 +99,9 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
   // 0.5 * window.devicePixelRatio: 0.8 * window.devicePixelRatio
   useEffect(() => {
     if (isLandscape()) {
-      setCannonHorizontalScalar(0.6 * window.devicePixelRatio);
+      setCannonHorizontalScalar(0.5);
     } else {
-      setCannonHorizontalScalar(0.3 * window.devicePixelRatio);
+      setCannonHorizontalScalar(0.5);
     }
   }, []);
   //////////////////////// Canvas Drawings ///////////////////////////////////////
@@ -128,112 +128,50 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
       positionAndSizesInterface.current = new CanvasPositionAndSizes(canvasRef.current, cannonInfo, holsterInfo, MAX_RANGE);
       drawingInterface.current = new DrawingImages(positionAndSizesInterface.current)
     }
-  }, [cannonInfo, holsterInfo, MAX_SPEED, MAX_RANGE])
+  }, [cannonInfo, holsterInfo])
 
   useEffect(() => {
-    // console.log("Beginning environment on load")
-    // drawingInterface.current.drawEnvironmentOnLoad(
-    //   GROUND_LEVEL_SCALAR,
-    //   USER_ANCHOR_POINT,
-    //   MAX_SPEED,
-    //   launchVelocity,
-    //   target_range,
-    //   target_altitude,
-    //   foregroundRef,
-    //   holsterRef,
-    //   cannonRef,
-    //   velocityBarRef,
-    //   velocitySliderRef,
-    //   heightScaleRef,
-    //   heightArrowRef,
-    //   targetRef
-    // )
-
-    // console.log("In same useEffect - starting environment (not on load)")
-    // drawingInterface.current.drawEnvironment(
-    //   GROUND_LEVEL_SCALAR,
-    //   USER_ANCHOR_POINT,
-    //   MAX_SPEED,
-    //   launchVelocity,
-    //   elevationAngle,
-    //   target_range,
-    //   target_altitude,
-    //   foregroundRef,
-    //   holsterRef,
-    //   cannonRef,
-    //   velocityBarRef,
-    //   velocitySliderRef,
-    //   heightScaleRef,
-    //   heightArrowRef,
-    //   targetRef
-    // )
+    ctxRef.current = canvasRef.current.getContext('2d');
 
 
-    drawingInterface.current.drawForegroundOnLoad(GROUND_LEVEL_SCALAR, foregroundRef.current);
-    
-    drawingInterface.current.drawHolsterOnLoad(holsterRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawCannonOnLoad(cannonRef.current, USER_ANCHOR_POINT);
-
-
-    drawingInterface.current.drawVelocityBarOnLoad(velocityBarRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawVelocitySliderOnLoad(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
-
-    drawingInterface.current.drawHeightScaleOnLoad(heightScaleRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawHeightArrowOnLoad(heightArrowRef.current, USER_ANCHOR_POINT);
-
-    drawingInterface.current.drawTargetOnLoad(
-      USER_ANCHOR_POINT, 
+    drawingInterface.current.drawEnvironmentOnLoad(
       GROUND_LEVEL_SCALAR, 
-      targetRef.current, 
-      target_range, 
-      target_altitude
+      USER_ANCHOR_POINT,
+      MAX_SPEED,
+      launchVelocity,
+      target_range,
+      target_altitude,
+      foregroundRef, 
+      holsterRef, 
+      cannonRef, 
+      velocityBarRef, 
+      velocitySliderRef, 
+      heightScaleRef, 
+      heightArrowRef,
+      targetRef
     )
-
-  }, [USER_ANCHOR_POINT, launchVelocity, MAX_SPEED, target_altitude, target_range])
+  }, [USER_ANCHOR_POINT, launchVelocity])
 
   useEffect(() => {
-
-    // drawingInterface.current.drawEnvironment(
-    //   GROUND_LEVEL_SCALAR,
-    //   USER_ANCHOR_POINT,
-    //   MAX_SPEED,
-    //   launchVelocity,
-    //   elevationAngle,
-    //   target_range,
-    //   target_altitude,
-    //   foregroundRef,
-    //   holsterRef,
-    //   cannonRef,
-    //   velocityBarRef,
-    //   velocitySliderRef,
-    //   heightScaleRef,
-    //   heightArrowRef,
-    //   targetRef
-    // )
-    if (ctxRef && ctxRef.current) {
-      ctxRef.current.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
-    }
-
-    drawingInterface.current.drawForeground(GROUND_LEVEL_SCALAR, foregroundRef.current);
-
-    drawingInterface.current.drawHolster(holsterRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawCannon(cannonRef.current, -elevationAngle, USER_ANCHOR_POINT);
-
-    drawingInterface.current.drawHeightPlatform(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR);
-    
-    drawingInterface.current.drawVelocityBar(velocityBarRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawVelocitySlider(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
-    
-    drawingInterface.current.drawHeightScale(heightScaleRef.current, USER_ANCHOR_POINT);
-    drawingInterface.current.drawHeightArrow(heightArrowRef.current, USER_ANCHOR_POINT);
-
-    drawingInterface.current.drawTarget(
-      USER_ANCHOR_POINT, 
+    drawingInterface.current.drawEnvironment(
       GROUND_LEVEL_SCALAR, 
-      targetRef.current, 
-      target_range, 
-      target_altitude
+      USER_ANCHOR_POINT,
+      MAX_SPEED,
+      launchVelocity,
+      elevationAngle,
+      target_range,
+      target_altitude,
+      foregroundRef, 
+      holsterRef, 
+      cannonRef, 
+      velocityBarRef, 
+      velocitySliderRef, 
+      heightScaleRef, 
+      heightArrowRef,
+      targetRef
     )
+
+    
   })
 
   //////////////////////// Changing Angles Mouse Events ////////////////////////
@@ -406,37 +344,36 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
 
       </canvas>
 
-      <div className="Canvas_BillyGoat">
-        {loadedCanvas && 
-          <InputPanel 
-            setElevationAngle={setElevationAngle} 
-            setLaunchVelocity={setLaunchVelocity} 
-            setUserAnchorPoint={setUserAnchorPoint}
-            MAX_SPEED={MAX_SPEED} 
-            angleInputRef={angleInputRef} 
-            velocityInputRef={velocityInputRef}
-            heightInputRef={heightInputRef}
-            canvas={canvasRef.current}
-            USER_ANCHOR_PONT={USER_ANCHOR_POINT}
-            MAX_HORIZONTAL_RANGE={MAX_RANGE}
-            CANNON_HORIZONTAL_SCALAR={CANNON_HORIZONTAL_SCALAR}
-            GROUND_LEVEL_SCALAR={GROUND_LEVEL_SCALAR}
-          />
-        }
-
-        <FireButton 
-          fireCannon={() => fireCannon(
-            ctxRef.current, 
-            canvasRef.current, 
-            USER_ANCHOR_POINT, 
-            launchVelocity, 
-            elevationAngle, 
-            GROUND_LEVEL_SCALAR, 
-            MAX_RANGE, 
-            width
-          )} 
+      {loadedCanvas && 
+        <InputPanel 
+          setElevationAngle={setElevationAngle} 
+          setLaunchVelocity={setLaunchVelocity} 
+          setUserAnchorPoint={setUserAnchorPoint}
+          MAX_SPEED={MAX_SPEED} 
+          angleInputRef={angleInputRef} 
+          velocityInputRef={velocityInputRef}
+          heightInputRef={heightInputRef}
+          canvas={canvasRef.current}
+          USER_ANCHOR_PONT={USER_ANCHOR_POINT}
+          MAX_HORIZONTAL_RANGE={MAX_RANGE}
+          CANNON_HORIZONTAL_SCALAR={CANNON_HORIZONTAL_SCALAR}
+          GROUND_LEVEL_SCALAR={GROUND_LEVEL_SCALAR}
         />
-      </div>
+      }
+
+      <FireButton 
+        fireCannon={() => fireCannon(
+          ctxRef.current, 
+          canvasRef.current, 
+          USER_ANCHOR_POINT, 
+          launchVelocity, 
+          elevationAngle, 
+          GROUND_LEVEL_SCALAR, 
+          MAX_RANGE, 
+          width
+        )} 
+      />
+
     </div>
     
   )

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -124,31 +124,62 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
 
   useEffect(() => {
     if (canvasRef.current) {
+      ctxRef.current = canvasRef.current.getContext('2d');
       positionAndSizesInterface.current = new CanvasPositionAndSizes(canvasRef.current, cannonInfo, holsterInfo, MAX_RANGE);
       drawingInterface.current = new DrawingImages(positionAndSizesInterface.current)
     }
-  }, [cannonInfo, holsterInfo])
+  }, [cannonInfo, holsterInfo, MAX_SPEED, MAX_RANGE])
 
   useEffect(() => {
-    ctxRef.current = canvasRef.current.getContext('2d');
+    // console.log("Beginning environment on load")
+    // drawingInterface.current.drawEnvironmentOnLoad(
+    //   GROUND_LEVEL_SCALAR,
+    //   USER_ANCHOR_POINT,
+    //   MAX_SPEED,
+    //   launchVelocity,
+    //   target_range,
+    //   target_altitude,
+    //   foregroundRef,
+    //   holsterRef,
+    //   cannonRef,
+    //   velocityBarRef,
+    //   velocitySliderRef,
+    //   heightScaleRef,
+    //   heightArrowRef,
+    //   targetRef
+    // )
+
+    // console.log("In same useEffect - starting environment (not on load)")
+    // drawingInterface.current.drawEnvironment(
+    //   GROUND_LEVEL_SCALAR,
+    //   USER_ANCHOR_POINT,
+    //   MAX_SPEED,
+    //   launchVelocity,
+    //   elevationAngle,
+    //   target_range,
+    //   target_altitude,
+    //   foregroundRef,
+    //   holsterRef,
+    //   cannonRef,
+    //   velocityBarRef,
+    //   velocitySliderRef,
+    //   heightScaleRef,
+    //   heightArrowRef,
+    //   targetRef
+    // )
 
 
     drawingInterface.current.drawForegroundOnLoad(GROUND_LEVEL_SCALAR, foregroundRef.current);
     
-    drawingInterface.current.drawDefaultCannon(cannonRef.current, holsterRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawHolsterOnLoad(holsterRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawCannonOnLoad(cannonRef.current, USER_ANCHOR_POINT);
 
-    drawingInterface.current.drawDefaultVelocitySlider(
-      velocityBarRef.current,
-      velocitySliderRef.current,
-      launchVelocity,
-      MAX_SPEED,
-      USER_ANCHOR_POINT
-    )
-    drawingInterface.current.drawDefaultHeightScale(
-      heightScaleRef.current,
-      heightArrowRef.current,
-      USER_ANCHOR_POINT
-    )
+
+    drawingInterface.current.drawVelocityBarOnLoad(velocityBarRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawVelocitySliderOnLoad(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
+
+    drawingInterface.current.drawHeightScaleOnLoad(heightScaleRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawHeightArrowOnLoad(heightArrowRef.current, USER_ANCHOR_POINT);
 
     drawingInterface.current.drawTargetOnLoad(
       USER_ANCHOR_POINT, 
@@ -158,38 +189,43 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
       target_altitude
     )
 
-  }, [USER_ANCHOR_POINT, launchVelocity])
+  }, [USER_ANCHOR_POINT, launchVelocity, MAX_SPEED, target_altitude, target_range])
 
   useEffect(() => {
-    ctxRef.current = canvasRef.current.getContext('2d');
+
+    // drawingInterface.current.drawEnvironment(
+    //   GROUND_LEVEL_SCALAR,
+    //   USER_ANCHOR_POINT,
+    //   MAX_SPEED,
+    //   launchVelocity,
+    //   elevationAngle,
+    //   target_range,
+    //   target_altitude,
+    //   foregroundRef,
+    //   holsterRef,
+    //   cannonRef,
+    //   velocityBarRef,
+    //   velocitySliderRef,
+    //   heightScaleRef,
+    //   heightArrowRef,
+    //   targetRef
+    // )
     if (ctxRef && ctxRef.current) {
       ctxRef.current.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
     }
 
     drawingInterface.current.drawForeground(GROUND_LEVEL_SCALAR, foregroundRef.current);
 
-    drawingInterface.current.drawRotatedCannon(
-      -elevationAngle, 
-      cannonRef.current, 
-      holsterRef.current, 
-      USER_ANCHOR_POINT,
-    );
+    drawingInterface.current.drawHolster(holsterRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawCannon(cannonRef.current, -elevationAngle, USER_ANCHOR_POINT);
 
     drawingInterface.current.drawHeightPlatform(USER_ANCHOR_POINT, GROUND_LEVEL_SCALAR);
     
-    drawingInterface.current.drawVelocitySlider(
-      velocityBarRef.current, 
-      velocitySliderRef.current, 
-      launchVelocity, 
-      MAX_SPEED, 
-      USER_ANCHOR_POINT,
-    )
+    drawingInterface.current.drawVelocityBar(velocityBarRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawVelocitySlider(velocitySliderRef.current, launchVelocity, MAX_SPEED, USER_ANCHOR_POINT);
     
-    drawingInterface.current.drawHeightScale(
-      heightScaleRef.current,
-      heightArrowRef.current,
-      USER_ANCHOR_POINT,
-    )
+    drawingInterface.current.drawHeightScale(heightScaleRef.current, USER_ANCHOR_POINT);
+    drawingInterface.current.drawHeightArrow(heightArrowRef.current, USER_ANCHOR_POINT);
 
     drawingInterface.current.drawTarget(
       USER_ANCHOR_POINT, 

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -47,6 +47,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
 
   const { width, height } = useWindowSize();
 
+
   //// Element References
   const ctxRef = useRef(null);
   const canvasRef = useRef(null);
@@ -127,18 +128,34 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
       ctxRef.current = canvasRef.current.getContext('2d');
       positionAndSizesInterface.current = new CanvasPositionAndSizes(canvasRef.current, cannonInfo, holsterInfo, MAX_RANGE);
       drawingInterface.current = new DrawingImages(positionAndSizesInterface.current)
+      console.log("Drawing on load environment:")
+      // drawingInterface.current.drawEnvironmentOnLoad(
+      //   GROUND_LEVEL_SCALAR, 
+      //   USER_ANCHOR_POINT,
+      //   MAX_SPEED,
+      //   launchVelocity,
+      //   target_range,
+      //   target_altitude,
+      //   foregroundRef, 
+      //   holsterRef, 
+      //   cannonRef, 
+      //   velocityBarRef, 
+      //   velocitySliderRef, 
+      //   heightScaleRef, 
+      //   heightArrowRef,
+      //   targetRef
+      // )
+      console.log("Completed on load environment")
     }
-  }, [cannonInfo, holsterInfo])
+  }, [cannonInfo, holsterInfo, MAX_RANGE])
 
-  useEffect(() => {
-    ctxRef.current = canvasRef.current.getContext('2d');
-
-
-    drawingInterface.current.drawEnvironmentOnLoad(
+  window.onload = () => {
+    drawingInterface.current.drawEnvironment(
       GROUND_LEVEL_SCALAR, 
       USER_ANCHOR_POINT,
       MAX_SPEED,
       launchVelocity,
+      elevationAngle,
       target_range,
       target_altitude,
       foregroundRef, 
@@ -150,7 +167,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
       heightArrowRef,
       targetRef
     )
-  }, [USER_ANCHOR_POINT, launchVelocity])
+  }
 
   useEffect(() => {
     drawingInterface.current.drawEnvironment(
@@ -170,9 +187,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude}) {
       heightArrowRef,
       targetRef
     )
-
-    
-  })
+  }, [MAX_SPEED, USER_ANCHOR_POINT, elevationAngle, launchVelocity, target_altitude, target_range, width, height])
 
   //////////////////////// Changing Angles Mouse Events ////////////////////////
 

--- a/src/processingFunctions/findPivotGlobalCoords.js
+++ b/src/processingFunctions/findPivotGlobalCoords.js
@@ -1,5 +1,5 @@
 export function findPivotGlobalCoords(canvas, USER_ANCHOR_POINT) {
-  const pivX = window.innerWidth * USER_ANCHOR_POINT[0]
+  const pivX = window.innerWidth * USER_ANCHOR_POINT[0] * window.devicePixelRatio;
 
   const pivY = canvas.height * USER_ANCHOR_POINT[1]
 


### PR DESCRIPTION
Basically, in canvas, I use window.onload (as described [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event))

This waits for all resources including images to be loaded before drawing the environment for the first time

Then as usual i use the useEffect to continuously erase and redraw when state changes occur

Interestingly, by using the window.onload, I don't need to set img.onload functions for each individual image so all those functions in the drawingImages class may now be useless