### PR TITLE
Improving the scrolling/highlighted region of the interactive map

### DIFF
--- a/src/components/canvasParts/Canvas.tsx
+++ b/src/components/canvasParts/Canvas.tsx
@@ -22,7 +22,6 @@ import velocitySliderImg from "../../images/velocity/velocitySlider.png"
 import heightScaleImg from "../../images/height/heightBar.png"
 import heightArrowImg from "../../images/height/heightIndicator.png"
 
-
 import targetImg from "../../images/targets/trainingTarget.png"
 
 
@@ -223,11 +222,17 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
 
   useEffect(() => {
     if (canvasRef.current && canvasRef.current.parentElement) {
+
+      const canvasParent = canvasRef.current.parentElement;
+
+      const scrollLeft = canvasParent.scrollLeft;
+      const clientWidth = canvasParent.clientWidth;
+      const scrollWidth = canvasParent.scrollWidth;
       gameStateRef.current = [
         elevationAngle, 
         launchVelocity, 
         USER_ANCHOR_POINT[1], 
-        (canvasRef.current.parentElement.clientWidth / canvasRef.current.width) * window.devicePixelRatio
+        (scrollLeft + clientWidth) / scrollWidth
       ]
       setStateChangeTrigger(x => x ^ 1);
     }

--- a/src/components/canvasParts/Canvas.tsx
+++ b/src/components/canvasParts/Canvas.tsx
@@ -370,7 +370,6 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
               GROUND_LEVEL_SCALAR, USER_ANCHOR_POINT, target_altitude, target_range
             )}        
             gameStateRef={gameStateRef}
-            userStateRef={userStateRef}
           />}
 
         {readyToDraw && 

--- a/src/components/canvasParts/Canvas.tsx
+++ b/src/components/canvasParts/Canvas.tsx
@@ -36,6 +36,7 @@ import { CanvasMouseMove } from "../../OOP/canvasMouseEvents/CanvasMouseMove.tsx
 import { CanvasImagePreloader } from "../../OOP/CanvasImagePreloader.tsx"
 import InteractiveMap from "./InteractiveMap.tsx"
 import { fix_dpi } from "../fixDPI.tsx"
+import { calculateScrollScalar } from "../../processingFunctions/scrollScalarCalculation.tsx"
 
 
 interface CanvasProps {
@@ -223,16 +224,11 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
   useEffect(() => {
     if (canvasRef.current && canvasRef.current.parentElement) {
 
-      const canvasParent = canvasRef.current.parentElement;
-
-      const scrollLeft = canvasParent.scrollLeft;
-      const clientWidth = canvasParent.clientWidth;
-      const scrollWidth = canvasParent.scrollWidth;
       gameStateRef.current = [
         elevationAngle, 
         launchVelocity, 
         USER_ANCHOR_POINT[1], 
-        (scrollLeft + clientWidth) / scrollWidth
+        calculateScrollScalar(canvasRef.current)
       ]
       setStateChangeTrigger(x => x ^ 1);
     }
@@ -281,14 +277,10 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
     <>
       
       <div id="container" onScroll={(e) => {
-        if (userStateRef.current !== "firing") {
+        if (canvasRef.current && userStateRef.current !== "firing") {
           userStateRef.current = "scrolling";
-          console.log("Set user state to scrolling")
-          const scrollLeft = (e.target as HTMLDivElement).scrollLeft;
-          const clientWidth = (e.target as HTMLDivElement).clientWidth;
-          const scrollWidth = (e.target as HTMLDivElement).scrollWidth;
           gameStateRef.current = [
-            elevationAngle, launchVelocity, USER_ANCHOR_POINT[1], (scrollLeft + clientWidth) / scrollWidth
+            elevationAngle, launchVelocity, USER_ANCHOR_POINT[1], calculateScrollScalar(canvasRef.current)
           ]
           setStateChangeTrigger(x => x ^ 1);
         }
@@ -378,6 +370,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
               GROUND_LEVEL_SCALAR, USER_ANCHOR_POINT, target_altitude, target_range
             )}        
             gameStateRef={gameStateRef}
+            userStateRef={userStateRef}
           />}
 
         {readyToDraw && 
@@ -389,6 +382,7 @@ export default function Canvas({MAX_RANGE, target_range, target_altitude, userSt
               elevationAngle, 
               GROUND_LEVEL_SCALAR, 
               width,
+              gameStateRef,
               userStateRef,
               setStateChangeTrigger
             )} 

--- a/src/components/canvasParts/InteractiveMap.tsx
+++ b/src/components/canvasParts/InteractiveMap.tsx
@@ -35,7 +35,7 @@ export default function InteractiveMap({parentCanvasRef, pivotCoords, targetCoor
 
   const rightSideContainer = rightMostScalar * parentCanvasRef.current.width;
   const parentDivContainerWidth = (parentCanvasRef.current.parentElement as HTMLDivElement).clientWidth;
-  const leftSideContainer = rightSideContainer -  parentDivContainerWidth * window.devicePixelRatio;
+  const leftSideContainer = rightSideContainer - parentDivContainerWidth * window.devicePixelRatio;
 
   const highlighter_right_side = (rightSideContainer * scale) * window.devicePixelRatio;
   const highlighter_left_side = (leftSideContainer * scale) * window.devicePixelRatio;
@@ -44,6 +44,7 @@ export default function InteractiveMap({parentCanvasRef, pivotCoords, targetCoor
   const highlighter_height = INTERACTIVE_MAP_HEIGHT * window.devicePixelRatio;
   const highlighter_x = highlighter_left_side;
   const highlighter_y = 0;
+
 
 
   const clickedOn = useRef(false);
@@ -83,13 +84,15 @@ export default function InteractiveMap({parentCanvasRef, pivotCoords, targetCoor
         ctx.fillStyle = "red";
         ctx.stroke()
         ctx.fill(); 
-      } 
+      }
     }
   })
+
 
   ///////////////////////////////////////////////////////////////////////////////////
 
   function mouseDown(e: React.MouseEvent<HTMLCanvasElement, MouseEvent>) {
+
     clickedOn.current = true;
     clicked_x.current = e.pageX;
 
@@ -136,8 +139,6 @@ export default function InteractiveMap({parentCanvasRef, pivotCoords, targetCoor
       newVal = 1;
     }
     gameStateRef.current[3] = newVal;
-
-    console.log(`gameStateRef.current[3] = ${gameStateRef.current[3]}`)
   }
   ///////////////////////////////////////////////////////////////////////////////////
   

--- a/src/processingFunctions/fireCannon.tsx
+++ b/src/processingFunctions/fireCannon.tsx
@@ -1,6 +1,7 @@
 import { RefObject } from "react";
 import { CanvasPositionAndSizes } from "../OOP/CanvasPositionAndSizes.tsx";
 import { drawCircle } from "./drawingFunctions.tsx";
+import { calculateScrollScalar } from "./scrollScalarCalculation.tsx";
 
 // needs canvas, user anchor point, launch vel, elevation angle, ground level scalar   
 export function fireCannon(
@@ -10,6 +11,7 @@ export function fireCannon(
     elevationAngle: number, 
     GROUND_LEVEL_SCALAR: number, 
     width: number,
+    gameStateRef: RefObject<GameState>,
     userStateRef: RefObject<UserState>,
     setStateChangeTrigger: React.Dispatch<React.SetStateAction<number>>
 
@@ -48,9 +50,13 @@ export function fireCannon(
             left: (x) / window.devicePixelRatio - width / 2,
             behavior: "instant"
           });
+
+          gameStateRef.current[3] = calculateScrollScalar(canvas)
           
           if (ctx) {
+            setStateChangeTrigger(x => x ^ 1);
             drawCircle(ctx, x, y, 5, "blue", "black");
+            
           }
           if (initial_y
             - (initial_v * Math.sin(angle_rad) * currTime) 

--- a/src/processingFunctions/scrollScalarCalculation.tsx
+++ b/src/processingFunctions/scrollScalarCalculation.tsx
@@ -1,0 +1,6 @@
+import { RefObject } from "react";
+
+export function calculateScrollScalar(canvas: HTMLCanvasElement) {
+  const canvasContainer = canvas.parentNode as HTMLDivElement;
+  return (canvasContainer.scrollLeft + canvasContainer.clientWidth) / canvasContainer.scrollWidth
+}


### PR DESCRIPTION
Made this branch originally for the following reason:
- consider a user has scrolled all the way to the right - the interactive map's highlighted region follows this scroll as expected
- now say the user uses the input panel to change the elevation angle
- this will cause the state trigger to be triggered causing a re-render; the map hears this trigger and resets itself, causing the highlighted region to reset its position, even though the scroll position is unchanged

- The **fix** was to be more accurate regarding what the gameState's scroll value should be assigned to in the Canvas component in the useEffect that re-evaluates the gameState when the trigger is heard

On top of the above bug, the following was fixed:
- when the fire button is clicked, the user's screen scrolls BUT the interactive map does NOT follow this particular scrolling
- The fix was to update the game state inside the fireCannon function with the appropriate value as the screen scrolled
- I also had to call the state trigger function for each new cannon ball so that the interactive map would hear the new gameState scroll value and update the highlighted region accordingly 